### PR TITLE
Vol 133/set up view all users page

### DIFF
--- a/api/controllers/userController.ts
+++ b/api/controllers/userController.ts
@@ -7,12 +7,12 @@ const colRef = collection(db, "users");
 
 async function getUsers(req: Request, res: Response): Promise<void> {
     const userDocs = await getDocs(colRef);
-    const users = userDocs.docs.map(doc => doc.data());
+    const users = userDocs.docs.map(doc => ({...doc.data(), id: doc.id}));
     
-    res.json(users);
+    res.json(users).status(200);
     
     // Print out the users for testing purposes
-    console.log(users);
+    // console.log(users);
 }
 
 async function addUser(req: Request, res: Response): Promise<void> {
@@ -44,10 +44,19 @@ async function addUser(req: Request, res: Response): Promise<void> {
 
 async function deleteUser(req: Request, res: Response): Promise<void> {
     const userRef = doc(db, "users", req.body.id);
+    const docSnapshot = (await getDoc(userRef));
+    
+    if (!docSnapshot.exists()) {
+      console.log("Document does not exist")
+      res.status(404).send("Document not found")
+      return;
+    }
+
+    const user = { id:docSnapshot.id, ...docSnapshot.data() }
 
     await deleteDoc(userRef);
 
-    res.json("User deleted");
+    res.json(user).status(200);
 
     // Print out message for testing purposes
     console.log("User deleted");
@@ -61,7 +70,6 @@ async function getUser(req: Request, res: Response): Promise<void> {
     
     // Print out message for testing purposes
     console.log(user);
-
 }
 
 export { getUsers, addUser, deleteUser, getUser };

--- a/api/controllers/userController.ts
+++ b/api/controllers/userController.ts
@@ -1,75 +1,90 @@
 import { db } from '../config/firebase';
-import { collection, getDocs, addDoc, deleteDoc, doc, getDoc } from 'firebase/firestore';
+import { collection, getDocs, addDoc, deleteDoc, doc, getDoc, updateDoc } from 'firebase/firestore';
 import { Request, Response } from 'express';
 
 
 const colRef = collection(db, "users");
 
 async function getUsers(req: Request, res: Response): Promise<void> {
-    const userDocs = await getDocs(colRef);
-    const users = userDocs.docs.map(doc => ({...doc.data(), id: doc.id}));
-    
-    res.json(users).status(200);
-    
-    // Print out the users for testing purposes
-    // console.log(users);
+  const userDocs = await getDocs(colRef);
+  const users = userDocs.docs.map(doc => ({ ...doc.data(), id: doc.id }));
+
+  res.json(users).status(200);
+
+  // Print out the users for testing purposes
+  console.log(users);
 }
 
 async function addUser(req: Request, res: Response): Promise<void> {
-    // Get all users
-    const userDocs = await getDocs(colRef);
-    const users = userDocs.docs.map(doc => doc.data());
-    const studentID = req.body.studentID;
+  // Get all users
+  const userDocs = await getDocs(colRef);
+  const users = userDocs.docs.map(doc => doc.data());
+  const studentID = req.body.studentID;
 
-    // Check if studentID is already in use
-    for (let i = 0; i < users.length; i++) {
-        if (users[i].studentID === studentID) {
-            // Student ID is not unique, send error message and return
-            res.status(400).send("Student ID must be unique");
+  // Check if studentID is already in use
+  for (let i = 0; i < users.length; i++) {
+    if (users[i].studentID === studentID) {
+      // Student ID is not unique, send error message and return
+      res.status(400).send("Student ID must be unique");
 
-            // Print out error message for testing purposes
-            console.log("Student ID must be unique");
-            return;
-        }
+      // Print out error message for testing purposes
+      console.log("Student ID must be unique");
+      return;
     }
+  }
 
-    // New studentID is unique, add user to database
-    const newUser = await addDoc(colRef, req.body);
+  // New studentID is unique, add user to database
+  const newUser = await addDoc(colRef, req.body);
 
-    res.json(newUser.id);
+  res.json(newUser.id);
 
-    // Print out the new user id for testing purposes
-    console.log(newUser.id)
+  // Print out the new user id for testing purposes
+  console.log(newUser.id)
 }
 
 async function deleteUser(req: Request, res: Response): Promise<void> {
-    const userRef = doc(db, "users", req.body.id);
-    const docSnapshot = (await getDoc(userRef));
-    
-    if (!docSnapshot.exists()) {
-      console.log("Document does not exist")
-      res.status(404).send("Document not found")
-      return;
-    }
+  const userRef = doc(db, "users", req.body.id);
+  const docSnapshot = (await getDoc(userRef));
 
-    const user = { id:docSnapshot.id, ...docSnapshot.data() }
+  if (!docSnapshot.exists()) {
+    console.log("Document does not exist")
+    res.status(404).send("Document not found")
+    return;
+  }
 
-    await deleteDoc(userRef);
+  const user = { id: docSnapshot.id, ...docSnapshot.data() }
 
-    res.json(user).status(200);
+  await deleteDoc(userRef);
 
-    // Print out message for testing purposes
-    console.log("User deleted");
+  res.json(user).status(200);
+
+  // Print out message for testing purposes
+  console.log("User deleted");
 }
 
 async function getUser(req: Request, res: Response): Promise<void> {
-    const userRef = doc(db, "users", req.body.id);
-    const user = (await getDoc(userRef)).data();
-    
-    res.json(user);
-    
-    // Print out message for testing purposes
-    console.log(user);
+  const userRef = doc(db, "users", req.body.id);
+  const user = (await getDoc(userRef)).data();
+
+  res.json(user);
+
+  // Print out message for testing purposes
+  console.log(user);
 }
 
-export { getUsers, addUser, deleteUser, getUser };
+async function updateUser(req: Request, res: Response): Promise<void> {
+  const userID = req.body.id;
+  const userRef = doc(db, "users", userID)
+
+  const docSnapshot = await getDoc(userRef);
+  if (!docSnapshot.exists()) {
+    res.status(404).send("User does not exist")
+    return;
+  }
+
+  await updateDoc(userRef, req.body);
+  const updatedUser = docSnapshot.data()
+  res.status(200).json(updatedUser)
+}
+
+export { getUsers, addUser, deleteUser, getUser, updateUser };

--- a/api/routes/api/users.ts
+++ b/api/routes/api/users.ts
@@ -1,5 +1,5 @@
 const express = require("express");
-import { getUsers, addUser, deleteUser, getUser } from '../../controllers/userController';
+import { getUsers, addUser, deleteUser, getUser, updateUser } from '../../controllers/userController';
 
 const router = express.Router();
 
@@ -7,5 +7,6 @@ router.get("/getUsers", getUsers);
 router.post("/addUser", addUser);
 router.delete("/removeUser", deleteUser);
 router.get("/getUser", getUser)
+router.patch("/updateUser", updateUser)
 
 export default router;

--- a/api/routes/endpoints.ts
+++ b/api/routes/endpoints.ts
@@ -4,7 +4,6 @@ const express = require("express");
 const router = express.Router();
 import { Request, Response } from "express";
 
-
 import userEndpoints from './api/users';
 
 import { db } from "../config/firebase";
@@ -14,7 +13,9 @@ import {
   addDoc,
   deleteDoc,
   doc,
+  getDoc,
 } from "firebase/firestore";
+import { json } from "stream/consumers";
 
 // Temp test to show that DB is working
 router.get("/getTest", async (req: Request, res: Response) => {
@@ -39,7 +40,7 @@ router.use("/", userEndpoints);
 // testing routers
 
 // get all events
-router.get("/", (request: Request, response: Response) => {
+router.get("/", async (request: Request, response: Response) => {
   getDocs(colRef)
     .then((snapshot) => {
       let events: any = [];
@@ -54,8 +55,10 @@ router.get("/", (request: Request, response: Response) => {
 });
 
 // get a single one
-router.get("/:id", (request: Request, response: Response) => {
-  response.json({ message: "'/:id' is working to GET a SINGLE one" });
+router.get("/:id", async (request: Request, response: Response) => {
+  const eventRef = doc(db, "events", request.params.id)
+  const event = (await getDoc(eventRef)).data()
+  response.status(200).json(event)
 });
 
 // post a single one

--- a/web/package.json
+++ b/web/package.json
@@ -1,5 +1,5 @@
 {
-  "proxy": "https://localhost:3000",
+  "proxy": "http://localhost:3000",
   "name": "web",
   "private": true,
   "version": "0.0.0",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import RegisterForm from '@components/RegisterForm';
 import TestingComponent from '@components/TestComponent';
 import AdminUsers from '@pages/AdminUsers';
 import { UsersContextProvider } from './context/UserContext';
+import Admin from '@pages/Admin';
 
 const router = createBrowserRouter([
   {
@@ -27,12 +28,15 @@ const router = createBrowserRouter([
     element: <TestingComponent />,
   },
   {
+    path: '/admin',
+    element: <Admin />,
+  },
+  {
     path: '/admin/users',
     element: 
       <UsersContextProvider>
         <AdminUsers />
-      </UsersContextProvider>
-    ,
+      </UsersContextProvider>,
   },
 ]);
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,8 @@ import MainMenu from '@pages/MainMenu';
 import NotFound from '@pages/NotFound';
 import RegisterForm from '@components/RegisterForm';
 import TestingComponent from '@components/TestComponent';
+import AdminUsers from '@pages/AdminUsers';
+import { UsersContextProvider } from './context/UserContext';
 
 const router = createBrowserRouter([
   {
@@ -20,9 +22,18 @@ const router = createBrowserRouter([
     path: 'register',
     element: <RegisterForm />,
   },
-  { path: '/testing',
-    element: <TestingComponent />
-  }
+  { 
+    path: '/testing',
+    element: <TestingComponent />,
+  },
+  {
+    path: '/admin/users',
+    element: 
+      <UsersContextProvider>
+        <AdminUsers />
+      </UsersContextProvider>
+    ,
+  },
 ]);
 
 export default function App() {

--- a/web/src/Hooks/UseUsersContext.tsx
+++ b/web/src/Hooks/UseUsersContext.tsx
@@ -1,0 +1,12 @@
+import { UsersContext } from "../context/UserContext";
+import { useContext } from 'react'
+
+export const useUsersContext = () => {
+  const context = useContext(UsersContext)
+
+  if (!context) {
+    throw Error('useUsersContext must be used inside a UsersContextProvider')
+  }
+
+  return context
+}

--- a/web/src/components/UserDetails.tsx
+++ b/web/src/components/UserDetails.tsx
@@ -1,0 +1,33 @@
+import { User } from "@pages/AdminUsers";
+import { useUsersContext } from "../Hooks/UseUsersContext";
+// import { useEffect } from 'react';
+
+const UserDetails = ({ user }: { user: User }) => {
+  const { dispatch } = useUsersContext()
+
+  const handleClick = async () => {
+    const response = await fetch('http://localhost:3000/api/removeUser', {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ id: user.id })
+    })
+    const json = await response.json()
+
+    if (response.ok) {
+      dispatch({type: 'DELETE_USER', payload: json})
+    }
+  }
+
+  return (
+    <div className="flex border">
+      <p className="w-40">{user.firstName}</p>
+      <p className="w-40">{user.lastName}</p>
+      <p className="w-40">{user.studentID}</p>
+      <span onClick={handleClick} className="flex justify-self-end hover:cursor-pointer">Delete</span>
+    </div>
+  )
+}
+
+export default UserDetails

--- a/web/src/components/UserDetails.tsx
+++ b/web/src/components/UserDetails.tsx
@@ -96,9 +96,9 @@ const UserDetails = ({ user }: { user: User }) => {
 
     if (response.ok) {
       setDetails({...details})
+      dispatch({type: 'UPDATE_USER', payload: {...details}})
     }
 
-    dispatch({type: 'UPDATE_USER', payload: {...details}})
     disableEditMode();
   }
 

--- a/web/src/components/UserDetails.tsx
+++ b/web/src/components/UserDetails.tsx
@@ -1,11 +1,15 @@
 import { User } from "@pages/AdminUsers";
 import { useUsersContext } from "../Hooks/UseUsersContext";
+import { useState } from "react";
 // import { useEffect } from 'react';
 
 const UserDetails = ({ user }: { user: User }) => {
+  const [firstName, setFirstName] = useState(user.firstName);
+  const [lastName, setLastName] = useState(user.lastName);
+  const [studentID, setStudentID] = useState(user.studentID);
   const { dispatch } = useUsersContext()
 
-  const handleClick = async () => {
+  const handleClickDelete = async () => {
     const response = await fetch('http://localhost:3000/api/removeUser', {
       method: 'DELETE',
       headers: {
@@ -20,12 +24,21 @@ const UserDetails = ({ user }: { user: User }) => {
     }
   }
 
+  const handleClickEdit = () => {
+
+  }
+
   return (
-    <div className="flex border">
-      <p className="w-40">{user.firstName}</p>
-      <p className="w-40">{user.lastName}</p>
-      <p className="w-40">{user.studentID}</p>
-      <span onClick={handleClick} className="flex justify-self-end hover:cursor-pointer">Delete</span>
+    <div className="flex border justify-between items-center h-10 px-2">
+      <div className="flex">
+        <p className="w-40 m-0">{firstName}</p>
+        <p className="w-40 m-0">{lastName}</p>
+        <p className="w-40 m-0">{studentID}</p>
+      </div>
+      <div className="flex gap-4">
+        <span onClick={handleClickEdit}className="hover:cursor-pointer">Edit</span>
+        <span onClick={handleClickDelete} className="hover:cursor-pointer">Delete</span>
+      </div>
     </div>
   )
 }

--- a/web/src/components/UserDetails.tsx
+++ b/web/src/components/UserDetails.tsx
@@ -116,27 +116,27 @@ const UserDetails = ({ user }: { user: User }) => {
           {/* Main info edit mode */}
           <div className="flex border border-gray-600 justify-between items-center h-10 px-2 rounded gap-2">
             <div className="flex flex-[0_0_79%]">
-              <div className="flex-[1] m-0 border">
+              <div className="flex-[1] m-0">
                 <input type="text" className="w-full" value={details.firstName}
                   onChange={(e) => setDetails((oldDetails) => ({ ...oldDetails, firstName: e.target.value }))}
                 />
               </div>
-              <div className="flex-[1] m-0 border">
+              <div className="flex-[1] m-0">
                 <input type="text" className="w-full" value={details.lastName}
                   onChange={(e) => setDetails((oldDetails) => ({ ...oldDetails, lastName: e.target.value }))}
                 />
               </div>
-              <div className="flex-[2] m-0 border">
+              <div className="flex-[2] m-0">
                 <input type="text" className="w-full" value={details.email}
                   onChange={(e) => setDetails((oldDetails) => ({ ...oldDetails, email: e.target.value }))}
                 />
               </div>
-              <div className="flex-[1] m-0 border">
+              <div className="flex-[1] m-0">
                 <input type="text" className="w-full" value={details.mobile}
                   onChange={(e) => setDetails((oldDetails) => ({ ...oldDetails, mobile: e.target.value }))}
                 />
               </div>
-              <div className="flex-[1] m-0 border">
+              <div className="flex-[1] m-0">
                 <input type="text" className="w-full" value={details.dOB}
                   onChange={(e) => setDetails((oldDetails) => ({ ...oldDetails, dOB: e.target.value }))}
                 />
@@ -152,7 +152,7 @@ const UserDetails = ({ user }: { user: User }) => {
               </div>
             </div>
 
-            <div className="flex justify-end flex-[0_0_21%] gap-2 border">
+            <div className="flex justify-end flex-[0_0_21%] gap-2">
               <span onClick={handleCancel} className="hover:cursor-pointer border border-gray-400 px-2 rounded">Cancel</span>
               <span onClick={handleSave} className="hover:cursor-pointer rounded px-2 text-green-600 border border-green-600">Save</span>
             </div>
@@ -247,15 +247,15 @@ const UserDetails = ({ user }: { user: User }) => {
           {/* Main info display mode */}
           <div className="flex border border-gray-600 justify-between items-center h-10 px-2 rounded gap-2">
             <div className="flex flex-[0_0_79%]">
-              <div className="flex-[1] m-0 border">{details.firstName}</div>
-              <div className="flex-[1] m-0 border">{details.lastName}</div>
-              <div className="flex-[2] m-0 border">{details.email}</div>
-              <div className="flex-[1] m-0 border">{details.mobile}</div>
-              <div className="flex-[1] m-0 border">{details.dOB}</div>
-              <div className="flex-[1] m-0 border">{details.gender}</div>
+              <div className="flex-[1] m-0">{details.firstName}</div>
+              <div className="flex-[1] m-0">{details.lastName}</div>
+              <div className="flex-[2] m-0">{details.email}</div>
+              <div className="flex-[1] m-0">{details.mobile}</div>
+              <div className="flex-[1] m-0">{details.dOB}</div>
+              <div className="flex-[1] m-0r">{details.gender}</div>
             </div>
 
-            <div className="flex justify-end flex-[0_0_21%] gap-2 border">
+            <div className="flex justify-end flex-[0_0_21%] gap-2">
               <span onClick={toggleShowDetails} className="hover:cursor-pointer border border-gray-400 px-2 rounded">{showDetails ? "Hide Details" : "Show Details"}</span>
               <span onClick={enableEditMode} className="hover:cursor-pointer border border-gray-400 px-2 rounded">Edit</span>
               <span onClick={handleClickDelete} className="hover:cursor-pointer rounded px-2 text-red-600 border border-red-600">Delete</span>

--- a/web/src/components/UserDetails.tsx
+++ b/web/src/components/UserDetails.tsx
@@ -1,14 +1,33 @@
-import { User } from "@pages/AdminUsers";
 import { useUsersContext } from "../Hooks/UseUsersContext";
 import { useState } from "react";
-// import { useEffect } from 'react';
+
+// Not sure if this should be in the file?
+export interface User {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  mobile: string;
+  dOB: string;
+  gender: string;
+  year: string;
+  dietary: string;
+  license: string;
+  accessibility: string;
+  emFirstName: string;
+  emLastName: string;
+  emMobile: string;
+  emRelationship: string;
+}
 
 const UserDetails = ({ user }: { user: User }) => {
-  const [firstName, setFirstName] = useState(user.firstName);
-  const [lastName, setLastName] = useState(user.lastName);
-  const [studentID, setStudentID] = useState(user.studentID);
-  const [isEditMode, setIsEditMode] = useState(false);
+  // Local state
+  const [details, setDetails] = useState<User>({ ...user });
 
+  const [isEditMode, setIsEditMode] = useState(false);
+  const [showDetails, setShowDetails] = useState(false);
+
+  // dispatch function to update global state
   const { dispatch } = useUsersContext()
 
   const handleClickDelete = async () => {
@@ -23,19 +42,28 @@ const UserDetails = ({ user }: { user: User }) => {
         body: JSON.stringify({ id: user.id })
       })
       const json = await response.json()
-  
+
       if (response.ok) {
-        dispatch({type: 'DELETE_USER', payload: json})
+        dispatch({ type: 'DELETE_USER', payload: json })
       }
     }
   }
 
-  const toggleEditMode = () => {
-    setIsEditMode(!isEditMode);
+  const enableEditMode = () => {
+    setIsEditMode(true);
+    setShowDetails(true);
+  }
+
+  const disableEditMode = () => {
+    setIsEditMode(false);
+  }
+
+  const toggleShowDetails = () => {
+    setShowDetails(!showDetails)
   }
 
   const handleSave = async () => {
-    const updatedUser = {id: user.id, firstName, lastName, studentID}
+    const updatedUser = { ...details }
 
     const response = await fetch('http://localhost:3000/api/updateUser', {
       method: 'PATCH',
@@ -45,57 +73,214 @@ const UserDetails = ({ user }: { user: User }) => {
       body: JSON.stringify(updatedUser)
     })
     const json = await response.json()
-    
+
     if (response.ok) {
       console.log("User updated", json)
     }
 
-    toggleEditMode();
+    disableEditMode();
   }
 
+  // Uses original state to revert back to old values
   const handleCancel = () => {
-    setFirstName(user.firstName)
-    setLastName(user.lastName)
-    setStudentID(user.studentID)
+    setDetails({ ...user })
 
-    toggleEditMode();
+    disableEditMode();
   }
 
+  //User Details component
   return (
-    <div className="flex border border-gray-600 justify-between items-center h-10 px-2 rounded">
-        {isEditMode ? (
-          <div className="flex">
-            <input type="text" className="w-40 m-0" value={firstName} 
-              onChange={(e) => (setFirstName(e.target.value))}
-            />
-            <input type="text" className="w-40 m-0" value={lastName} 
-              onChange={(e) => (setLastName(e.target.value))}
-            />
-            <input type="text" className="w-40 m-0" value={studentID} 
-              onChange={(e) => (setStudentID(e.target.value))}
-            />
-          </div>
-          
-        ) : (
-          <div className="flex">
-            <p className="w-40 m-0">{firstName}</p>
-            <p className="w-40 m-0">{lastName}</p>
-            <p className="w-40 m-0">{studentID}</p>
-          </div>
-        )}
+    <div className="">
+      {isEditMode ? (
+        <div className="">
+          {/* Main info edit mode */}
+          <div className="flex border border-gray-600 justify-between items-center h-10 px-2 rounded gap-2">
+            <div className="flex flex-[0_0_79%]">
+              <div className="flex-[1] m-0 border">
+                <input type="text" className="w-full" value={details.firstName}
+                  onChange={(e) => setDetails((oldDetails) => ({ ...oldDetails, firstName: e.target.value }))}
+                />
+              </div>
+              <div className="flex-[1] m-0 border">
+                <input type="text" className="w-full" value={details.lastName}
+                  onChange={(e) => (setDetails({ ...details, lastName: e.target.value }))}
+                />
+              </div>
+              <div className="flex-[2] m-0 border">
+                <input type="text" className="w-full" value={details.email}
+                  onChange={(e) => (setDetails({ ...details, email: e.target.value }))}
+                />
+              </div>
+              <div className="flex-[1] m-0 border">
+                <input type="text" className="w-full" value={details.mobile}
+                  onChange={(e) => (setDetails({ ...details, mobile: e.target.value }))}
+                />
+              </div>
+              <div className="flex-[1] m-0 border">
+                <input type="text" className="w-full" value={details.dOB}
+                  onChange={(e) => (setDetails({ ...details, dOB: e.target.value }))}
+                />
+              </div>
+              <div className="flex flex-[1]">
+                <select className="w-full" id="" value={details.gender} onChange={(e) => setDetails({ ...details, gender: e.target.value })}>
+                  <option value="Male">Male</option>
+                  <option value="Female">Female</option>
+                  <option value="Non-Binary">Non-binary</option>
+                  <option value="Prefer not to say">Prefer not to say</option>
+                  <option value="Other">Other</option>
+                </select>
+              </div>
+            </div>
 
-        {isEditMode ? (
-          <div className="flex gap-4">
-            <span onClick={handleCancel}className="hover:cursor-pointer border border-gray-400 px-2 rounded">Cancel</span>
-            <span onClick={handleSave}className="hover:cursor-pointer rounded px-2 text-green-600 border border-green-600">Save</span>
+            <div className="flex justify-end flex-[0_0_21%] gap-2 border">
+              <span onClick={handleCancel} className="hover:cursor-pointer border border-gray-400 px-2 rounded">Cancel</span>
+              <span onClick={handleSave} className="hover:cursor-pointer rounded px-2 text-green-600 border border-green-600">Save</span>
+            </div>
           </div>
-        ) : (
-          <div className="flex gap-4">
-            <span onClick={toggleEditMode}className="hover:cursor-pointer border border-gray-400 px-2 rounded">Edit</span>
-            <span onClick={handleClickDelete} className="hover:cursor-pointer rounded px-2 text-red-600 border border-red-600">Delete</span>
+
+          {/* Details Panel Edit Mode */}
+          {showDetails ? (
+            <div className="">
+              <div className="flex p-2 border border-black border-t-0 rounded">
+                <div className="flex-col flex-[1]">
+                  <div className="flex flex-nowrap">
+
+                    <div className="flex w-[50%]">
+                      <div className="flex-auto text-center">Year Level:</div>
+                      <select className="flex-auto mr-4" id="" value={details.year} onChange={(e) => setDetails({ ...details, year: e.target.value })}>
+                        <option value="1st Year">1st Year</option>
+                        <option value="2nd Year">2nd Year</option>
+                        <option value="3rd Year">3rd Year</option>
+                        <option value="4th Year">4th Year</option>
+                        <option value="Post-graduate">Post-graduate</option>
+                        <option value="Other">Other</option>
+                      </select>
+                    </div>
+
+                    <div className="flex w-[50%]">
+                      <div className="flex-auto text-center">License:</div>
+                      <select className="flex-auto mr-4" id="" value={details.license} onChange={(e) => setDetails({ ...details, license: e.target.value })}>
+                        <option value="Full">Full</option>
+                        <option value="Restricted">Restricted</option>
+                        <option value="None">None</option>
+                      </select>
+                    </div>
+
+                  </div>
+
+                  <div className="flex">
+                    <div className="flex-[1]">
+                      <div className="underline">Dietary Requirements</div>
+                      <input type="text" className="" value={details.dietary}
+                        onChange={(e) => (setDetails({ ...details, dietary: e.target.value }))}
+                      />
+                    </div>
+
+                    <div className="flex-[1]">
+                      <div className="underline">Accessibility Requirements</div>
+                      <input type="text" className="" value={details.accessibility}
+                        onChange={(e) => (setDetails({ ...details, accessibility: e.target.value }))}
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex flex-col flex-[1]">
+                  <div className="underline">Emergency Contact</div>
+                  <div className="flex gap-2 flex-wrap">
+                    <div className="flex gap-2 w-[49%]">
+                      <div className="flex-shrink-0">First Name: </div>
+                      <input type="text" className="w-full" value={details.emFirstName}
+                        onChange={(e) => setDetails((oldDetails) => ({ ...oldDetails, emFirstName: e.target.value }))}
+                      />
+                    </div>
+                    <div className="flex gap-2 w-[49%]">
+                      <div className="flex-shrink-0">Last Name: </div>
+                      <input type="text" className="w-full" value={details.emLastName}
+                        onChange={(e) => setDetails((oldDetails) => ({ ...oldDetails, emLastName: e.target.value }))}
+                      />
+                    </div>
+                    <div className="flex gap-2 w-[49%]">
+                      <div className="">Mobile: </div>
+                      <input type="text" className="w-full" value={details.emMobile}
+                        onChange={(e) => setDetails((oldDetails) => ({ ...oldDetails, emMobile: e.target.value }))}
+                      />
+                    </div>
+                    <div className="flex gap-2 w-[49%]">
+                      <div className="">Relationship: </div>
+                      <input type="text" className="w-full" value={details.emRelationship}
+                        onChange={(e) => setDetails((oldDetails) => ({ ...oldDetails, emRelationship: e.target.value }))}
+                      />
+                    </div>
+                  </div>
+
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div></div>
+          )}
+        </div>
+
+      ) : (
+        <div className="">
+          {/* Main info display mode */}
+          <div className="flex border border-gray-600 justify-between items-center h-10 px-2 rounded gap-2">
+            <div className="flex flex-[0_0_79%]">
+              <div className="flex-[1] m-0 border">{details.firstName}</div>
+              <div className="flex-[1] m-0 border">{details.lastName}</div>
+              <div className="flex-[2] m-0 border">{details.email}</div>
+              <div className="flex-[1] m-0 border">{details.mobile}</div>
+              <div className="flex-[1] m-0 border">{details.dOB}</div>
+              <div className="flex-[1] m-0 border">{details.gender}</div>
+            </div>
+
+            <div className="flex justify-end flex-[0_0_21%] gap-2 border">
+              <span onClick={toggleShowDetails} className="hover:cursor-pointer border border-gray-400 px-2 rounded">{showDetails ? "Hide Details" : "Show Details"}</span>
+              <span onClick={enableEditMode} className="hover:cursor-pointer border border-gray-400 px-2 rounded">Edit</span>
+              <span onClick={handleClickDelete} className="hover:cursor-pointer rounded px-2 text-red-600 border border-red-600">Delete</span>
+            </div>
           </div>
-        )}
-      </div>
+
+          {/* Details panel display mode */}
+          {showDetails ? (
+            <div className="flex p-2 border border-black border-t-0 rounded">
+              <div className="flex-col flex-[1]">
+                <div className="flex justify-evenly">
+                  <div className="">Year Level: {details.year}</div>
+                  <div className="">Driver's License: {details.license}</div>
+                </div>
+
+                <div className="flex">
+                  <div className="flex-[1]">
+                    <div className="underline">Dietary Requirements</div>
+                    <div className="">{details.dietary}</div>
+                  </div>
+
+                  <div className="flex-[1]">
+                    <div className="underline">Accessibility Requirements</div>
+                    <div className="">{details.accessibility}</div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="flex flex-col flex-[1]">
+                <div className="underline">Emergency Contact</div>
+                <div className="flex flex-col">
+                  <div className="flex gap-1">
+                    <div className="">Name: {details.emFirstName} {details.emLastName}</div>
+                  </div>
+                  <div className="">Mobile: {details.emMobile}</div>
+                  <div className="">Relationship: {details.emRelationship}</div>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div></div>
+          )}
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/web/src/components/UserDetails.tsx
+++ b/web/src/components/UserDetails.tsx
@@ -7,39 +7,95 @@ const UserDetails = ({ user }: { user: User }) => {
   const [firstName, setFirstName] = useState(user.firstName);
   const [lastName, setLastName] = useState(user.lastName);
   const [studentID, setStudentID] = useState(user.studentID);
+  const [isEditMode, setIsEditMode] = useState(false);
+
   const { dispatch } = useUsersContext()
 
   const handleClickDelete = async () => {
-    const response = await fetch('http://localhost:3000/api/removeUser', {
-      method: 'DELETE',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ id: user.id })
-    })
-    const json = await response.json()
+    const confirmDelete = window.confirm('Are you sure want to remove ' + user.firstName + '?')
 
-    if (response.ok) {
-      dispatch({type: 'DELETE_USER', payload: json})
+    if (confirmDelete) {
+      const response = await fetch('http://localhost:3000/api/removeUser', {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ id: user.id })
+      })
+      const json = await response.json()
+  
+      if (response.ok) {
+        dispatch({type: 'DELETE_USER', payload: json})
+      }
     }
   }
 
-  const handleClickEdit = () => {
+  const toggleEditMode = () => {
+    setIsEditMode(!isEditMode);
+  }
 
+  const handleSave = async () => {
+    const updatedUser = {id: user.id, firstName, lastName, studentID}
+
+    const response = await fetch('http://localhost:3000/api/updateUser', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(updatedUser)
+    })
+    const json = await response.json()
+    
+    if (response.ok) {
+      console.log("User updated", json)
+    }
+
+    toggleEditMode();
+  }
+
+  const handleCancel = () => {
+    setFirstName(user.firstName)
+    setLastName(user.lastName)
+    setStudentID(user.studentID)
+
+    toggleEditMode();
   }
 
   return (
-    <div className="flex border justify-between items-center h-10 px-2">
-      <div className="flex">
-        <p className="w-40 m-0">{firstName}</p>
-        <p className="w-40 m-0">{lastName}</p>
-        <p className="w-40 m-0">{studentID}</p>
+    <div className="flex border border-gray-600 justify-between items-center h-10 px-2 rounded">
+        {isEditMode ? (
+          <div className="flex">
+            <input type="text" className="w-40 m-0" value={firstName} 
+              onChange={(e) => (setFirstName(e.target.value))}
+            />
+            <input type="text" className="w-40 m-0" value={lastName} 
+              onChange={(e) => (setLastName(e.target.value))}
+            />
+            <input type="text" className="w-40 m-0" value={studentID} 
+              onChange={(e) => (setStudentID(e.target.value))}
+            />
+          </div>
+          
+        ) : (
+          <div className="flex">
+            <p className="w-40 m-0">{firstName}</p>
+            <p className="w-40 m-0">{lastName}</p>
+            <p className="w-40 m-0">{studentID}</p>
+          </div>
+        )}
+
+        {isEditMode ? (
+          <div className="flex gap-4">
+            <span onClick={handleCancel}className="hover:cursor-pointer border border-gray-400 px-2 rounded">Cancel</span>
+            <span onClick={handleSave}className="hover:cursor-pointer rounded px-2 text-green-600 border border-green-600">Save</span>
+          </div>
+        ) : (
+          <div className="flex gap-4">
+            <span onClick={toggleEditMode}className="hover:cursor-pointer border border-gray-400 px-2 rounded">Edit</span>
+            <span onClick={handleClickDelete} className="hover:cursor-pointer rounded px-2 text-red-600 border border-red-600">Delete</span>
+          </div>
+        )}
       </div>
-      <div className="flex gap-4">
-        <span onClick={handleClickEdit}className="hover:cursor-pointer">Edit</span>
-        <span onClick={handleClickDelete} className="hover:cursor-pointer">Delete</span>
-      </div>
-    </div>
   )
 }
 

--- a/web/src/components/UserDetails.tsx
+++ b/web/src/components/UserDetails.tsx
@@ -98,6 +98,7 @@ const UserDetails = ({ user }: { user: User }) => {
       setDetails({...details})
     }
 
+    dispatch({type: 'UPDATE_USER', payload: {...details}})
     disableEditMode();
   }
 

--- a/web/src/context/UserContext.tsx
+++ b/web/src/context/UserContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useReducer, Dispatch, ReactNode } from "react";
-import { User } from "@pages/AdminUsers";
+import { User } from "@components/UserDetails";
 
 interface Action {
   type: string;
@@ -22,6 +22,15 @@ export const usersReducer = (state: {users: User[]}, action: Action) => {
     case 'DELETE_USER':
       return {
         users: state.users.filter((user) => user.id !== action.payload.id)
+      }
+    case 'UPDATE_USER':
+      return {
+        users: state.users.map((user) => {
+          if (user.id === action.payload.id) {
+            return {...user, ...action.payload}
+          }
+          return user;
+        })
       }
     default:
       return state;

--- a/web/src/context/UserContext.tsx
+++ b/web/src/context/UserContext.tsx
@@ -1,0 +1,41 @@
+import { createContext, useReducer, Dispatch, ReactNode } from "react";
+import { User } from "@pages/AdminUsers";
+
+interface Action {
+  type: string;
+  payload: any;
+}
+
+interface UsersContextType {
+  users: User[];
+  dispatch: Dispatch<Action>
+}
+
+export const UsersContext = createContext<UsersContextType | undefined>(undefined)
+
+export const usersReducer = (state: {users: User[]}, action: Action) => {
+  switch (action.type) {
+    case 'SET_USERS':
+      return {
+        users: action.payload
+      }
+    case 'DELETE_USER':
+      return {
+        users: state.users.filter((user) => user.id !== action.payload.id)
+      }
+    default:
+      return state;
+  }
+}
+
+export const UsersContextProvider = ({ children } : {children:ReactNode}) => {
+  const [state, dispatch] = useReducer(usersReducer, {
+    users: []
+  })
+
+  return (
+    <UsersContext.Provider value={{ users: state.users, dispatch }}>
+      { children }
+    </UsersContext.Provider>
+  )
+}

--- a/web/src/pages/Admin.tsx
+++ b/web/src/pages/Admin.tsx
@@ -1,0 +1,9 @@
+import { Link } from "react-router-dom";
+
+export default function Admin() {
+  return (
+    <div>
+      <Link to='/admin/users'>All users</Link>
+    </div>
+  )
+}

--- a/web/src/pages/Admin.tsx
+++ b/web/src/pages/Admin.tsx
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 
 export default function Admin() {
   return (
-    <div>
+    <div className="flex justify-center my-4">
       <Link to='/admin/users'>All users</Link>
     </div>
   )

--- a/web/src/pages/AdminUsers.tsx
+++ b/web/src/pages/AdminUsers.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from "react";
 import UserDetails from "@components/UserDetails";
-import { UsersContextProvider } from "../context/UserContext";
 import { useUsersContext } from "../Hooks/UseUsersContext";
 
 // Has to be a better way to do this. Users database kinda a mess so not sure what parameters there should be

--- a/web/src/pages/AdminUsers.tsx
+++ b/web/src/pages/AdminUsers.tsx
@@ -32,7 +32,12 @@ export default function AdminUsers() {
   }, [users])
 
   return (
-      <div className="border w-[80%] m-auto my-8">
+      <div className="flex flex-col w-[80%] m-auto my-8 gap-2">
+        <div className="flex flex-row px-2">
+          <div className="w-40">First Name</div>
+          <div className="w-40">Last Name</div>
+          <div className="w-40">Student ID</div>
+        </div>
         {users && users.map((user: User) => (
           <UserDetails key={user.id} user={user} />
         ))}

--- a/web/src/pages/AdminUsers.tsx
+++ b/web/src/pages/AdminUsers.tsx
@@ -1,0 +1,42 @@
+import { useEffect } from "react";
+import UserDetails from "@components/UserDetails";
+import { UsersContextProvider } from "../context/UserContext";
+import { useUsersContext } from "../Hooks/UseUsersContext";
+
+// Has to be a better way to do this. Users database kinda a mess so not sure what parameters there should be
+export interface User {
+  id: string;
+  firstName: string;
+  lastName: string;
+  studentID: string;
+}
+
+export default function AdminUsers() {
+  const {users, dispatch} = useUsersContext()
+
+  useEffect(() => {
+    const fetchAllUsers = async () => {
+      // Not sure why proxy doesn't work?
+      const response = await fetch('http://localhost:3000/api/getUsers')
+      const json = await response.json()
+
+      if (response.ok) {
+        dispatch({type: 'SET_USERS', payload: json})
+      }
+    }
+
+    fetchAllUsers();
+  }, [])
+
+  useEffect(() => {
+    console.log("users updated", users)
+  }, [users])
+
+  return (
+      <div className="border w-[80%] m-auto my-8">
+        {users && users.map((user: User) => (
+          <UserDetails key={user.id} user={user} />
+        ))}
+      </div>
+  );
+}

--- a/web/src/pages/AdminUsers.tsx
+++ b/web/src/pages/AdminUsers.tsx
@@ -1,14 +1,9 @@
 import { useEffect } from "react";
 import UserDetails from "@components/UserDetails";
 import { useUsersContext } from "../Hooks/UseUsersContext";
+import { User } from "../components/UserDetails"
 
-// Has to be a better way to do this. Users database kinda a mess so not sure what parameters there should be
-export interface User {
-  id: string;
-  firstName: string;
-  lastName: string;
-  studentID: string;
-}
+
 
 export default function AdminUsers() {
   const {users, dispatch} = useUsersContext()
@@ -32,11 +27,16 @@ export default function AdminUsers() {
   }, [users])
 
   return (
-      <div className="flex flex-col w-[80%] m-auto my-8 gap-2">
-        <div className="flex flex-row px-2">
-          <div className="w-40">First Name</div>
-          <div className="w-40">Last Name</div>
-          <div className="w-40">Student ID</div>
+      <div className="flex flex-col w-[90%] m-auto my-8 gap-2">
+        <div className="flex flex-[0_0_75%] px-2">
+          <div className="flex-[1]">First Name</div>
+          <div className="flex-[1]">Last Name</div>
+          <div className="flex-[2]">Email</div>
+          <div className="flex-[1]">Mobile</div>
+          <div className="flex-[1]">Date of Birth</div>
+          <div className="flex-[1]">Gender</div>
+          {/*Spacer div for alignment*/}
+          <div className="flex-[0_0_21%]"></div>
         </div>
         {users && users.map((user: User) => (
           <UserDetails key={user.id} user={user} />

--- a/web/src/pages/AdminUsers.tsx
+++ b/web/src/pages/AdminUsers.tsx
@@ -23,6 +23,10 @@ export default function AdminUsers() {
     fetchAllUsers();
   }, [])
 
+  useEffect(() => {
+    console.log(users)
+  }, [users])
+
   const filteredUsers = selectedYear === 'All' ? users : users.filter(user => user.year === selectedYear)
 
   return (

--- a/web/src/pages/AdminUsers.tsx
+++ b/web/src/pages/AdminUsers.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import UserDetails from "@components/UserDetails";
 import { useUsersContext } from "../Hooks/UseUsersContext";
 import { User } from "../components/UserDetails"
@@ -6,7 +6,8 @@ import { User } from "../components/UserDetails"
 
 
 export default function AdminUsers() {
-  const {users, dispatch} = useUsersContext()
+  const { users, dispatch } = useUsersContext()
+  const [selectedYear, setSelectedYear] = useState('All');
 
   useEffect(() => {
     const fetchAllUsers = async () => {
@@ -15,32 +16,42 @@ export default function AdminUsers() {
       const json = await response.json()
 
       if (response.ok) {
-        dispatch({type: 'SET_USERS', payload: json})
+        dispatch({ type: 'SET_USERS', payload: json })
       }
     }
 
     fetchAllUsers();
   }, [])
 
-  useEffect(() => {
-    console.log("users updated", users)
-  }, [users])
+  const filteredUsers = selectedYear === 'All' ? users : users.filter(user => user.year === selectedYear)
 
   return (
-      <div className="flex flex-col w-[90%] m-auto my-8 gap-2">
-        <div className="flex flex-[0_0_75%] px-2">
-          <div className="flex-[1]">First Name</div>
-          <div className="flex-[1]">Last Name</div>
-          <div className="flex-[2]">Email</div>
-          <div className="flex-[1]">Mobile</div>
-          <div className="flex-[1]">Date of Birth</div>
-          <div className="flex-[1]">Gender</div>
-          {/*Spacer div for alignment*/}
-          <div className="flex-[0_0_21%]"></div>
-        </div>
-        {users && users.map((user: User) => (
-          <UserDetails key={user.id} user={user} />
-        ))}
+    <div className="flex flex-col w-[90%] m-auto my-8 gap-2">
+      <div className="flex gap-2">
+        <div className="">Filter by year:</div>
+        <select value={selectedYear} onChange={(e) => setSelectedYear(e.target.value)} className="">
+          <option value="All">All</option>
+          <option value="1st Year">1st Year</option>
+          <option value="2nd Year">2nd Year</option>
+          <option value="3rd Year">3rd Year</option>
+          <option value="4th Year">4th Year</option>
+          <option value="Post-graduate">Post-graduate</option>
+          <option value="Other">Other</option>
+        </select>
       </div>
+      <div className="flex flex-[0_0_75%] px-2">
+        <div className="flex-[1]">First Name</div>
+        <div className="flex-[1]">Last Name</div>
+        <div className="flex-[2]">Email</div>
+        <div className="flex-[1]">Mobile</div>
+        <div className="flex-[1]">Date of Birth</div>
+        <div className="flex-[1]">Gender</div>
+        {/*Spacer div for alignment*/}
+        <div className="flex-[0_0_21%]"></div>
+      </div>
+      {filteredUsers && filteredUsers.map((user: User) => (
+        <UserDetails key={user.id} user={user} />
+      ))}
+    </div>
   );
 }


### PR DESCRIPTION
- Admin page is setup in this branch
- Filter by year level feature, can add more depending on requirements
- When editing, fields become clickable and fields that have limited options become dropdowns
- Modified the getUsers endpoint to return the document ID along with the data as user endpoints such as getUser and deleteUser require this
- Added an updateUser endpoint
- Modified getEvent endpoint to return the event data instead of a test message

- Haven't implemented viewing past events attended. Should be able to separate past from present by comparing with current date when we standardize how our dates will be stored?
- Delete will require a confirmation, currently just using the built-in window popup but later implement a modal component to use?
- Not sure how to do ADMIN protected routes, has this been setup yet?
- Not sure why proxy isn't working?

![image](https://github.com/user-attachments/assets/2a3a4693-fda6-47c2-96be-f1a1a0bf9950)
![image](https://github.com/user-attachments/assets/70719b75-607a-46b8-bf7f-481ede0e59fb)
