### PR TITLE
VOL-194 creating community page gallery and cards + dashboard layout

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,7 +10,7 @@ import TestingComponent from '@components/TestComponent';
 import SignUpPage from '@pages/SignUpPage';
 import RegisterModalErrorContextProvider from './context/RegisterModalErrorContextProvider';
 import RegisterErrorModal from '@components/RegisterErrorModal';
-import Dashboard from '@pages/Dashboard';
+import DashboardCommunity from '@pages/DashboardCommunity';
 
 const router = createBrowserRouter([
   {
@@ -36,7 +36,7 @@ const router = createBrowserRouter([
   },
   {
     path: '/dashboard',
-    element: <Dashboard />,
+    element: <DashboardCommunity />,
   },
 ]);
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -35,7 +35,7 @@ const router = createBrowserRouter([
     element: <TestingComponent />,
   },
   {
-    path: '/dashboard',
+    path: '/dashboard', // can probably change this to /dashboard/community or something idk, im not sure how we are handling changing tabs within the dashboard
     element: <DashboardCommunity />,
   },
 ]);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,7 @@ import TestingComponent from '@components/TestComponent';
 import SignUpPage from '@pages/SignUpPage';
 import RegisterModalErrorContextProvider from './context/RegisterModalErrorContextProvider';
 import RegisterErrorModal from '@components/RegisterErrorModal';
+import Dashboard from '@pages/Dashboard';
 
 const router = createBrowserRouter([
   {
@@ -32,6 +33,10 @@ const router = createBrowserRouter([
   {
     path: '/testing',
     element: <TestingComponent />,
+  },
+  {
+    path: '/dashboard',
+    element: <Dashboard />,
   },
 ]);
 

--- a/web/src/components/CommunityGallery.tsx
+++ b/web/src/components/CommunityGallery.tsx
@@ -1,0 +1,61 @@
+import axios from 'axios';
+import { useState, useEffect } from 'react';
+import CommunityGalleryCard from './CommunityGalleryCard';
+
+interface GalleryData {
+  title: string;
+  image: string;
+}
+
+const CommunityGallery = ({event, location}: {event: string, location: string}) => {
+
+// TEMPORARY DATA, we should be getting the profile data from somewhere
+const name = 'John Doe';
+const hours = '14';
+      const [data, setData] = useState<GalleryData[]>([
+    {
+      title: "Relay For Life", 
+      image: "/assets/EventHighlights/Events/RelayForLife/imgB.png"
+    },
+    {
+      title:"Volunteers Day",
+      image: "/assets/EventHighlights/Events/VolunteersDay/imgB.png"
+    },
+    {
+      title:"Blind Low Vision",
+      image: "/assets/EventHighlights/Events/BlindLowVision/imgB.png"
+    },
+    {
+      title: "Pub Quiz",
+      image: "/assets/EventHighlights/Events/PubQuiz/imgB.png"
+    }
+    ]);
+
+    useEffect(() => {
+    // Fetch gallery data
+    axios.get('http://localhost:3000/api/homepage/gallery')
+      .then((res) => {
+        setData(res.data);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+    }
+  , []);
+
+  
+    return (  
+        <div className='bg-white rounded-3xl py-10 px-12 text-subheading text-black shadow-lg'>
+            <p>People you may know from {event} at {location}</p>
+            <div className='flex gap-x-12 gap-y-2 flex-wrap'>
+                {/* hardcoded 4 people, this shoulded be mapped with however many people in the event?? */}
+                <CommunityGalleryCard name={name} hours={hours} profileImgLink={data[0].image}/>
+                <CommunityGalleryCard name={name} hours={hours} profileImgLink={data[1].image}/>
+                <CommunityGalleryCard name={name} hours={hours} profileImgLink={data[2].image}/>
+                <CommunityGalleryCard name={name} hours={hours} profileImgLink={data[3].image}/>
+            </div>
+        </div>
+    );
+}
+ 
+export default CommunityGallery;

--- a/web/src/components/CommunityGalleryCard.tsx
+++ b/web/src/components/CommunityGalleryCard.tsx
@@ -1,0 +1,48 @@
+import { BsFillPersonPlusFill } from "react-icons/bs";
+
+interface CommunityGalleryCardProps {
+  name: string;
+  hours: string;
+  profileImgLink: string;
+}
+
+const CommunityGalleryCard = ({name, hours, profileImgLink}: CommunityGalleryCardProps) => {
+    
+    const handleAddFriend = () => {
+        console.log('add friend');
+    };
+
+    return (  
+        <div className="w-[300px] h-[540px] rounded-2xl relative">
+            <div className="bg-primary h-[23%] rounded-t-2xl">
+            </div>
+
+            <div className="bg-lightGrey absolute w-[150px] top-[7%] right-[25%] rounded-full">
+                <img src={profileImgLink} alt="" className="w-[100%] aspect-square rounded-full"/>
+            </div>
+
+            <div className="border-b-[1px] border-x-[1px] rounded-b-2xl border-lightGrey2 h-[70%] flex flex-col items-center">
+                <p className="text-[25px] mt-[5.8rem] mb-0 text-black">{name}</p>
+                <p className="text-[40px] my-1 text-black">{hours}</p>
+                <p className="text-body text-m text-lightGrey2 mb-6">hours</p>
+
+                <div className="flex items-center w-[70%] justify-between">
+                    <div className="bg-lightGrey w-[40px] rounded-full flex-shrink-0">
+                        <img src={profileImgLink} alt="" className="aspect-square rounded-full"/>
+                    </div>
+                    {/* THIS DOES NOT HANDLE MUTUALS, IDK HOW WE ARE GONNA DO THAT SO I HAVENT MADE PROPS FOR THE BELOW STUFF */}
+                    <p className="text-body text-sm text-lightGrey2 ml-4 mb-0 mr-0">jaquallelina and 12 other mutual friends</p>
+                </div>
+
+                <button className="bg-primary text-body text-xl rounded-full py-2 px-9 mt-5 hover:bg-primary-dark hover:text-[#f7f7fb] active:bg-[#264268] active:translate-y-0.5 transition-all ease-in-out duration-100">
+                    <div className="flex items-center gap-2">
+                        <BsFillPersonPlusFill className="inline"/>
+                        <p className="m-0" onClick={ handleAddFriend }>Add Friend</p>
+                    </div>
+                </button>
+            </div>
+        </div>
+    );
+}
+ 
+export default CommunityGalleryCard;

--- a/web/src/components/CommunityGalleryWhole.tsx
+++ b/web/src/components/CommunityGalleryWhole.tsx
@@ -1,0 +1,60 @@
+/*
+ * So like the purpose of this file is to have a container for every event, then for every event it will have x amount of profile cards shown
+*/
+
+import axios from "axios";
+import { useState, useEffect } from "react";
+import CommunityGallery from "./CommunityGallery";
+
+interface EventData {
+  title: string;
+  location: string;
+}
+
+const CommunityGalleryWhole = () => {
+    // TEMPORARY DATA passing down events into community gallery vvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+      const [data, setData] = useState<EventData[]>([
+    {
+      title: "Quiz Night", 
+      location: "Uni"
+    },
+    {
+      title:"Launch Night",
+      location: "Somewhere"
+    },
+    {
+      title:"C",
+      location: "Somewhere"
+    },
+    {
+      title: "Beach Cleanup",
+      location: "Beach"
+    }
+    ]);
+
+  useEffect(() => {
+    // Fetch gallery data
+    axios.get('http://localhost:3000/api/homepage/highlights')
+      .then((res) => {
+        setData(res.data);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+    }
+  , []);
+// TEMPORARY ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    return ( 
+        <div>
+            {/* passing event data into community gallery*/}
+          {data.map(( event ) => (
+          <div className="mb-5">
+            <CommunityGallery event={event.title} location={event.location}/>
+          </div>
+        ))}
+        </div>
+     );
+}
+ 
+export default CommunityGalleryWhole;

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -3,11 +3,13 @@ import CommunityGalleryWhole from '@components/CommunityGalleryWhole';
 function Dashboard() {
   return (
     <div className="bg-[#F7F7FB] primary-background overflow-hidden flex flex-row">
+        {/* width of the left nav bar */}
         <div className='bg-primary w-[15%] h-auto'> 
             {/* place thing component here and remove bg-primary */}
             <h1>side thing</h1>
         </div>
 
+        {/* width of the everything else (other than the left nav bar) or in otherwords the length of the searchbar*/}
         <div className='flex flex-col w-[85%] marker:p-5'>
             <div className='bg-yellow-100'>
                 {/* place searchbar component here and remove bg-yellow */}
@@ -15,9 +17,13 @@ function Dashboard() {
             </div>
 
             <div className='flex flex-row'>
-                    <div className='flex flex-col w-[70%] px-5'>
-                        <CommunityGalleryWhole />
-                    </div>
+
+                {/* width of the gallery */}
+                <div className='flex flex-col w-[70%] px-5'>
+                    <CommunityGalleryWhole />
+                </div>
+                    
+                {/* width of the leadboard thing thing */}
                 <div className='bg-green-100 w-[30%] h-[40vw] px-5'>
                     {/* place thing component here and remove bg-green */}
                     <p>side thing</p>

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,0 +1,33 @@
+import CommunityGalleryWhole from '@components/CommunityGalleryWhole';
+
+function Dashboard() {
+  return (
+    <div className="bg-[#F7F7FB] primary-background overflow-hidden flex flex-row">
+        <div className='bg-primary w-[15%] h-auto'> 
+            {/* place thing component here and remove bg-primary */}
+            <h1>side thing</h1>
+        </div>
+
+        <div className='flex flex-col w-[85%] marker:p-5'>
+            <div className='bg-yellow-100'>
+                {/* place searchbar component here and remove bg-yellow */}
+                <h1>searchbar</h1>
+            </div>
+
+            <div className='flex flex-row'>
+                    <div className='flex flex-col w-[70%] px-5'>
+                        <CommunityGalleryWhole />
+                    </div>
+                <div className='bg-green-100 w-[30%] h-[40vw] px-5'>
+                    {/* place thing component here and remove bg-green */}
+                    <p>side thing</p>
+                </div>
+            
+            </div>
+        </div>
+        
+    </div>
+  );
+}
+
+export default Dashboard;

--- a/web/src/pages/DashboardCommunity.tsx
+++ b/web/src/pages/DashboardCommunity.tsx
@@ -1,6 +1,6 @@
 import CommunityGalleryWhole from '@components/CommunityGalleryWhole';
 
-function Dashboard() {
+function DashboardCommunity() {
   return (
     <div className="bg-[#F7F7FB] primary-background overflow-hidden flex flex-row">
         {/* width of the left nav bar */}
@@ -36,4 +36,4 @@ function Dashboard() {
   );
 }
 
-export default Dashboard;
+export default DashboardCommunity;

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -19,10 +19,10 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@esbuild/darwin-arm64@0.19.12":
+"@esbuild/win32-x64@0.19.12":
   version "0.19.12"
-  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz"
-  integrity sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==
+  resolved "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz"
+  integrity sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
@@ -604,15 +604,15 @@
   resolved "https://registry.npmjs.org/@remix-run/router/-/router-1.16.0.tgz"
   integrity sha512-Quz1KOffeEf/zwkCBM3kBtH4ZoZ+pT3xIXBG4PPW/XFtDP7EGhtTiC2+gpL9GnR7+Qdet5Oa6cYSvwKYg6kN9Q==
 
-"@rollup/rollup-darwin-arm64@4.9.6":
+"@rollup/rollup-win32-x64-msvc@4.9.6":
   version "4.9.6"
-  resolved "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.6.tgz"
-  integrity sha512-CqNNAyhRkTbo8VVZ5R85X73H3R5NX9ONnKbXuHisGWC0qRbTTxnF1U4V9NafzJbgGM0sHZpdO83pLPzq8uOZFw==
+  resolved "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.6.tgz"
+  integrity sha512-jqzNLhNDvIZOrt69Ce4UjGRpXJBzhUBzawMwnaDAwyHriki3XollsewxWzOzz+4yOFDkuJHtTsZFwMxhYJWmLQ==
 
-"@swc/core-darwin-arm64@1.4.0":
+"@swc/core-win32-x64-msvc@1.4.0":
   version "1.4.0"
-  resolved "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.4.0.tgz"
-  integrity sha512-UTJ/Vz+s7Pagef6HmufWt6Rs0aUu+EJF4Pzuwvr7JQQ5b1DZeAAUeUtkUTFx/PvCbM8Xfw4XdKBUZfrIKCfW8A==
+  resolved "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.4.0.tgz"
+  integrity sha512-e2xVezU7XZ2Stzn4i7TOQe2Kn84oYdG0M3A7XI7oTdcpsKCcKwgiMoroiAhqCv+iN20KNqhnWwJiUiTj/qN5AA==
 
 "@swc/core@^1.3.107":
   version "1.4.0"
@@ -1454,11 +1454,6 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
-
-fsevents@~2.3.2, fsevents@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Created community page gallery + dashboard layout

atm the gallery works by having a main gallery component for every (hardcoded) event. For each event it shows an amount of profile cards who attended the event (hardcoded, currently no functionality for this or storing this type of data). For each person a profile card is shown.

the pfp's are stretched but that's because they're not square images. I'm assuming that people should upload square images for their profile pics. also if there is no pfp it'll just be a grey circle.

The dashboard works pretty much the same way as the MainPage but there are just a bunch of divs to lay out every component correctly. Just replace the temporary tags and replace with your component. You don't need to worry about padding, that's done in the dashboard CSS.
![image](https://github.com/user-attachments/assets/e2f13c91-dd3e-4084-b51f-bd66a68087ee)
Go to dashboard with /dashboard
![image](https://github.com/user-attachments/assets/bc770ca4-cc9e-414b-a197-9837a79cd5be)

resolves #194 
