### PR TITLE
VOL-248/match the bg colour of the dashbaoard to the side nav bar

### DIFF
--- a/web/src/components/Dashboard/SideBarTab.tsx
+++ b/web/src/components/Dashboard/SideBarTab.tsx
@@ -9,10 +9,10 @@ type SideBarTabProps = {
 };
 
 const SideBarTab: React.FC<SideBarTabProps> = ({ unselected, selected, tabName, selectedTab, setSelectedTab, switchPage }) => {
-    const baseTabStyle = "flex flex-row gap-2 items-center hover:no-underline w-[190px] h-[84px] transition-all duration-[400] bg-primary mask-tab my-[-5px]"
+    const baseTabStyle = "flex flex-row gap-2 items-center hover:no-underline w-[190px] h-[84px] transition-all duration-[400] mask-tab my-[-3px]"
 
     return (
-        <button className={selectedTab === tabName ? baseTabStyle + " bg-white text-primary" : baseTabStyle + " hover:bg-[#ffffff40] text-white"} onClick={() => {
+        <button className={selectedTab === tabName ? baseTabStyle + " bg-[#F7F7FB] text-primary" : baseTabStyle + " bg-primary hover:bg-[#ffffff40] text-white"} onClick={() => {
             setSelectedTab(tabName)
             switchPage()}}> 
             <div className="w-auto h-auto">


### PR DESCRIPTION
- Updated colour of selected tab to match the bg colour of the dashboard
- Tabs now don't have a sight pixel overlap
- If zoomed in a lot will see that the edges don't perfectly align with the side due to the SVG mask but unnoticeable at normal screen size

![image](https://github.com/user-attachments/assets/e739e47a-7c8b-45ff-bf24-98588cb5effc)
