### PR TITLE
VOL-237/link-up-backend-to-announcements

### DIFF
--- a/web/src/components/Dashboard/DashboardAnnouncements/DashboardAnnouncement.tsx
+++ b/web/src/components/Dashboard/DashboardAnnouncements/DashboardAnnouncement.tsx
@@ -1,0 +1,23 @@
+function DashboardAnnouncement({announcement}:any) {
+    const startTimestamp = announcement.start_date_time
+    const startDate = startTimestamp.toDate()
+    const endTimestamp = announcement.end_date_time
+    const endDate = endTimestamp.toDate()
+
+    return (
+        <div className="max-w-[20vw] mt-[5px]">
+            <p className="text-[12px] mb-0 font-[450]">{announcement.title}</p>
+            <p className="text-[9px] m-0 leading-[1.2]">{announcement.message}</p>
+            <p className="text-[9px] m-0 leading-[1.2]">Created: {startDate.toLocaleDateString("en-US")}</p>
+            <p className="text-[9px] m-0 leading-[1.2]">Valid Until: {endDate.toLocaleDateString("en-US")}</p>
+            <div className="flex flex-wrap gap-1">
+                {announcement.tags && announcement.tags.map((tag: any, index: number) => (
+                    <p key={index} className="text-[9px] m-1 leading-[1.2] bg-gray-100 px-2 py-1 rounded-xl font-light">
+                    {tag}
+                    </p>
+                ))}
+            </div>
+          </div>
+    )
+}
+export default DashboardAnnouncement

--- a/web/src/components/Dashboard/DashboardAnnouncements/DashboardAnnouncements.tsx
+++ b/web/src/components/Dashboard/DashboardAnnouncements/DashboardAnnouncements.tsx
@@ -1,0 +1,13 @@
+import DashboardAnnouncement from "./DashboardAnnouncement"
+
+function DashboardAnnouncements({ announcements }: any) {
+  return (
+    <div className="max-h-[60vh] overflow-hidden overflow-y-scroll">
+      {announcements.map((announcement: any) => (
+        <DashboardAnnouncement key={announcement.id} announcement={announcement} />
+      ))}
+    </div>
+  );
+}
+
+export default DashboardAnnouncements;

--- a/web/src/components/Dashboard/NotificationTab.tsx
+++ b/web/src/components/Dashboard/NotificationTab.tsx
@@ -1,8 +1,32 @@
 interface NotificationTabProps {
   toggleNotificationTab: () => void;
 }
+import { useState, useEffect } from "react";
+import { db } from "../../firebase/firebase";
+import { collection, getDocs } from "firebase/firestore";
+import DashboardAnnouncements from "./DashboardAnnouncements/DashboardAnnouncements";
+
+const colref = collection(db, 'Announcements')
 
 function NotificationTab({ toggleNotificationTab }: NotificationTabProps) {
+  const [announcements, setAnnouncements] = useState<any[]>([]);
+  const [showAnnouncements, toggleShowAnnouncements] = useState(false);
+  
+  useEffect(() => {
+    getDocs(colref)
+      .then((snapshot) => {
+        let getAnnouncements: any[] = [];
+        snapshot.docs.forEach((doc) => {
+          getAnnouncements.push({ ...doc.data(), id: doc.id });
+        });
+        console.log(getAnnouncements); 
+        setAnnouncements(getAnnouncements);
+      })
+      .catch((err) => {
+        console.log(err.message);
+      });
+  }, []);
+
   return (
     <div className="absolute flex flex-row bg-white h-[96vh] w-[400px] shadow-lg top-2 right-4">
       <div>
@@ -11,27 +35,12 @@ function NotificationTab({ toggleNotificationTab }: NotificationTabProps) {
       <div className="flex flex-col font-light">
         <p className="font-sans font-medium text-black text-[38px] pt-[4vh] leading-[1.15] ml-4 mt-2">Notifications</p>
         <div className="flex flex-row justify-between ml-2 mr-8 mb-4">
-          <button className="text-black font-medium bg-gray-100 px-3 py-1 text-[11px] rounded-full mr-2 hover:text-white hover:bg-primary">All</button>
-          <button className="text-black font-medium bg-gray-100 px-3 py-1 text-[11px] rounded-full hover:text-white hover:bg-primary">Announcements</button>
-          <button className="text-black font-medium bg-gray-100 px-3 py-1 text-[11px] rounded-full ml-2 hover:text-white hover:bg-primary">Reminders</button>
+          <button className="text-black font-medium bg-gray-100 px-3 py-1 text-[11px] rounded-full mr-2 hover:text-white hover:bg-primary" onClick={()=>{toggleShowAnnouncements(false)}}>All</button>
+          <button className="text-black font-medium bg-gray-100 px-3 py-1 text-[11px] rounded-full hover:text-white hover:bg-primary" onClick={()=>{toggleShowAnnouncements(true)}}>Announcements</button>
+          <button className="text-black font-medium bg-gray-100 px-3 py-1 text-[11px] rounded-full ml-2 hover:text-white hover:bg-primary" onClick={()=>{toggleShowAnnouncements(false)}}>Reminders</button>
         </div>
-
-        <p className="text-[12px] font-medium ml-4 mt-3 mb-3">
-          WooHoo! You've reached a milestone!
-          <br />
-          <p className="text-[9px]">Posted 20 mins ago</p>
-        </p>
-
-        <div className="flex flex-row justify-between ml-4 mb-4">
-          <div>
-            <p className="text-[12px] mb-0 font-[450]">Launch Night</p>
-            <p className="text-[9px] m-0 leading-[1.2]">Monday 8th April 2024</p>
-            <p className="text-[9px] m-0 leading-[1.2]">6:00pm - 8:00pm</p>
-            <p className="text-[9px] ml-2 mr-8 leading-[1.2] bg-gray-100 px-2 p-1 mt-1 rounded-xl font-light">Club Event</p>
-          </div>
-          <div className="flex justify-center mt-4 mr-10">
-            <button className="bg-primary rounded-full text-[xx-small] h-5 w-5 py-1 px-1 hover:bg-blue-300">&gt;</button>
-          </div>
+        <div>
+          {showAnnouncements && <DashboardAnnouncements announcements={announcements}/>}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Display announcements from firebase to the announcement tab in the dashboard notifications.
Unsure of styling max-height when accounting for overflow when zoomed in/out.