### PR TITLE
Feat/working delete account

### DIFF
--- a/web/src/components/Dashboard/dashboardProfile/ProfileEditModal.tsx
+++ b/web/src/components/Dashboard/dashboardProfile/ProfileEditModal.tsx
@@ -183,6 +183,13 @@ const ProfileEditModal = () => {
     }
 }, []);
 
+  const deleteAccount = async () => {
+    if (!window.confirm("Are you sure you want to permanently delete your account? This cannot be undone.")) {
+      return;
+    }
+    // Add account deletion logic here if needed
+  }
+
   return (
     <div
       id='modalBackground'
@@ -537,7 +544,7 @@ const ProfileEditModal = () => {
                 Cancel
               </button>
               {page4 ? (
-                <button type='button' onClick={handleSubmit} className='inline-block text-white bg-primary hover:bg-primary-dark active:translate-y-0.5 transition-all ease-in-out duration-100 font-medium rounded-full text-sm w-full sm:w-auto px-5 py-2.5 text-center'>
+                <button type='button' onClick={deleteAccount} className='inline-block text-white bg-primary hover:bg-primary-dark active:translate-y-0.5 transition-all ease-in-out duration-100 font-medium rounded-full text-sm w-full sm:w-auto px-5 py-2.5 text-center'>
                   Delete Account
                 </button>
               ) : (

--- a/web/src/components/Dashboard/dashboardProfile/ProfileEditModal.tsx
+++ b/web/src/components/Dashboard/dashboardProfile/ProfileEditModal.tsx
@@ -183,6 +183,22 @@ const ProfileEditModal = () => {
     }
 }, []);
 
+  const deleteAccount = async () => {
+    if (!window.confirm("Are you sure you want to permanently delete your account? This cannot be undone.")) {
+      return;
+    }
+    try {
+      await axios.delete(`${appUrl}/api/users/${docId}`);
+      alert('Account deleted successfully.');
+      setShowModal(false);
+      // Redirect to home page or login page
+      window.location.href = '/';
+    } catch (error) {
+      console.error('Error deleting account:', error);
+      alert('An error occurred while deleting your account. Please try again.');
+    }
+  }
+
   return (
     <div
       id='modalBackground'
@@ -537,7 +553,7 @@ const ProfileEditModal = () => {
                 Cancel
               </button>
               {page4 ? (
-                <button type='button' onClick={handleSubmit} className='inline-block text-white bg-primary hover:bg-primary-dark active:translate-y-0.5 transition-all ease-in-out duration-100 font-medium rounded-full text-sm w-full sm:w-auto px-5 py-2.5 text-center'>
+                <button type='button' onClick={deleteAccount} className='inline-block text-white bg-primary hover:bg-primary-dark active:translate-y-0.5 transition-all ease-in-out duration-100 font-medium rounded-full text-sm w-full sm:w-auto px-5 py-2.5 text-center'>
                   Delete Account
                 </button>
               ) : (

--- a/web/src/components/Dashboard/dashboardProfile/ProfileEditModal.tsx
+++ b/web/src/components/Dashboard/dashboardProfile/ProfileEditModal.tsx
@@ -187,7 +187,16 @@ const ProfileEditModal = () => {
     if (!window.confirm("Are you sure you want to permanently delete your account? This cannot be undone.")) {
       return;
     }
-    // Add account deletion logic here if needed
+    try {
+      await axios.delete(`${appUrl}/api/users/${docId}`);
+      alert('Account deleted successfully.');
+      setShowModal(false);
+      // Redirect to home page or login page
+      window.location.href = '/';
+    } catch (error) {
+      console.error('Error deleting account:', error);
+      alert('An error occurred while deleting your account. Please try again.');
+    }
   }
 
   return (

--- a/web/src/components/Dashboard/dashboardProfile/ProfileEditModal.tsx
+++ b/web/src/components/Dashboard/dashboardProfile/ProfileEditModal.tsx
@@ -183,22 +183,6 @@ const ProfileEditModal = () => {
     }
 }, []);
 
-  const deleteAccount = async () => {
-    if (!window.confirm("Are you sure you want to permanently delete your account? This cannot be undone.")) {
-      return;
-    }
-    try {
-      await axios.delete(`${appUrl}/api/users/${docId}`);
-      alert('Account deleted successfully.');
-      setShowModal(false);
-      // Redirect to home page or login page
-      window.location.href = '/';
-    } catch (error) {
-      console.error('Error deleting account:', error);
-      alert('An error occurred while deleting your account. Please try again.');
-    }
-  }
-
   return (
     <div
       id='modalBackground'
@@ -553,7 +537,7 @@ const ProfileEditModal = () => {
                 Cancel
               </button>
               {page4 ? (
-                <button type='button' onClick={deleteAccount} className='inline-block text-white bg-primary hover:bg-primary-dark active:translate-y-0.5 transition-all ease-in-out duration-100 font-medium rounded-full text-sm w-full sm:w-auto px-5 py-2.5 text-center'>
+                <button type='button' onClick={handleSubmit} className='inline-block text-white bg-primary hover:bg-primary-dark active:translate-y-0.5 transition-all ease-in-out duration-100 font-medium rounded-full text-sm w-full sm:w-auto px-5 py-2.5 text-center'>
                   Delete Account
                 </button>
               ) : (

--- a/web/src/context/AuthenticationContextProvider.tsx
+++ b/web/src/context/AuthenticationContextProvider.tsx
@@ -81,16 +81,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, async (user) => {
-      initializeUser(user);
-      if (user) {
-        setCurrentUser(user);
-        setUid(user.uid);
-      } else {
-        setCurrentUser(null);
-        setUid('');
-      }
-    });
+    const unsubscribe = onAuthStateChanged(auth, initializeUser);
     return unsubscribe;
   }, []);
 

--- a/web/src/context/AuthenticationContextProvider.tsx
+++ b/web/src/context/AuthenticationContextProvider.tsx
@@ -81,7 +81,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, initializeUser);
+    const unsubscribe = onAuthStateChanged(auth, async (user) => {
+      initializeUser(user);
+      if (user) {
+        setCurrentUser(user);
+        setUid(user.uid);
+      } else {
+        setCurrentUser(null);
+        setUid('');
+      }
+    });
     return unsubscribe;
   }, []);
 


### PR DESCRIPTION
### Issue: #339, #340 

### What was added to the directory
- Delete button has been integrated successfully
- Deleting allow has a default google pop up to confirm deleteion

### How have you addressed this issue?
- The deleting function has already been implemented by the previous team
- Connected the deletion button to the handling function.
- Used window.confirm() to create that window

### Definition of Done:
- [x] AC met
- [ ] Applicable tests written
- [ ] Applicable documentation is written in GH wiki
- [ ] PR reviewed
- [ ] Merged into main/feature branch

### Notes / Links
Currently the deletion button does not delete the Google the user from Authentication table in Firebase